### PR TITLE
fix for issue #28

### DIFF
--- a/src/views/css/settings.css
+++ b/src/views/css/settings.css
@@ -127,11 +127,9 @@ header{
   }
   .toggle i:before{
     content: "\f204";
-    font-family: "FontAwesome";
   }
   .toggle.active i:before {
     content: "\f205";
-    font-family: "FontAwesome";
   }
 
 /* GENERAL TAB */


### PR DESCRIPTION
fix for toggle icons not displaying due to incorrect font-family name

![toggle_issue](https://user-images.githubusercontent.com/13255768/43077669-d0ffc9fc-8e90-11e8-9b82-b66dc6361d10.PNG)
