### PR TITLE
Typo "mininal" -> "minimal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
         <img src="build/icon.png" width="256" height="256" alt="ColorPicker icon" />
     </a>
     <h1 align="center">Colorpicker</h1>
-    <p align="center">A mininal but complete colorpicker desktop app</p>
+    <p align="center">A minimal but complete colorpicker desktop app</p>
     <p align="center">
         <img src="https://badgen.net/github/release/toinane/colorpicker/stable" />
         <img src="https://img.shields.io/github/downloads/toinane/colorpicker/total.svg">

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: colorpicker-app
 version: '2.0.4'
 base: core18
-summary: A mininal but complete Colorpicker desktop app
+summary: A minimal but complete Colorpicker desktop app
 description: |
   Colorpicker is a desktop tool with Electron to get and save colors code quickly for OSX, Windows and Linux!
 


### PR DESCRIPTION
Corrected typo "mininal" -> "minimal"; same typo is also in github's description.
Tell me if it is somwthing wanted.