### PR TITLE
Fix picker lagging and crashing

### DIFF
--- a/src/events/picker.js
+++ b/src/events/picker.js
@@ -1,93 +1,126 @@
-"use strict";
+'use strict';
 
-const { ipcMain, screen } = require("electron");
-const robot = require("robotjs");
+const { ipcMain, screen } = require('electron');
+const robot = require('robotjs');
 
 let mouseEvent;
 let color;
+let lastUpdateTime;
 
 module.exports = (storage, browsers) => {
-  const { picker, colorpicker } = browsers;
+	const { picker, colorpicker } = browsers;
+	const windowDestroyDelay = 100;
+	const pickerUpdateDelay = 25;
 
-  let closePicker = (newColor) => {
-    if (typeof newColor !== "string") { newColor = color; }
-    if (picker.getWindow()) {
-      colorpicker.getWindow().webContents.send("changeColor", newColor);
-      colorpicker.getWindow().focus();
-      ipcMain.removeListener("closePicker", closePicker);
-      ipcMain.removeListener("pickerRequested", (event) => { });
-      picker.getWindow().close();
-    }
-  };
+	let closePicker = (newColor) => {
+		if (typeof newColor !== 'string') {
+			newColor = color;
+		}
 
-  const linuxSupport = () => {
-    const ioHook = require("iohook");
+		const pickerWindow = picker.getWindow();
 
-    ioHook.start();
+		if (pickerWindow) {
+			mouseEvent.removeListener('move', mouseMoveEvent);
+			mouseEvent.removeListener('left-up', leftClickEvent);
+			mouseEvent.removeListener('right-up', closePicker);
+			colorpicker.getWindow().webContents.send('changeColor', newColor);
+			colorpicker.getWindow().focus();
+			ipcMain.removeListener('closePicker', closePicker);
 
-    ioHook.on("mousemove", (event) => {
-      if (!picker.getWindow()) { return; }
-      let realtime = storage.get("realtime", "picker");
-      let { x, y } = event;
-      let color = `#${robot.getPixelColor(parseInt(x), parseInt(y))}`;
-      picker.getWindow().setPosition(parseInt(x) - 50, parseInt(y) - 50);
-      picker.getWindow().webContents.send("updatePicker", color);
-      if (realtime) {
-        colorpicker.getWindow().webContents.send("previewColor", color);
-      }
-    });
+			setTimeout(() => {
+				if (pickerWindow && !pickerWindow.isDestroyed()) {
+					pickerWindow.destroy();
+				}
+			}, windowDestroyDelay);
+		}
+	};
 
-    ioHook.on("mouseup", (event) => {
-      if (!picker.getWindow()) { return; }
-      if (event.button === 2) { return closePicker(); }
-      let { x, y } = event;
-      closePicker(`#${robot.getPixelColor(parseInt(x), parseInt(y))}`);
-    });
+	const linuxSupport = () => {
+		const ioHook = require('iohook');
 
-    let pos = robot.getMousePos();
-    picker.getWindow().setPosition(parseInt(pos.x) - 50, parseInt(pos.y) - 50);
+		ioHook.start();
 
-    picker
-      .getWindow()
-      .webContents.send("updatePicker", robot.getPixelColor(pos.x, pos.y));
+		ioHook.on('mousemove', (event) => {
+			if (!picker.getWindow()) {
+				return;
+			}
+			let realtime = storage.get('realtime', 'picker');
+			let { x, y } = event;
+			let color = `#${robot.getPixelColor(parseInt(x), parseInt(y))}`;
+			picker.getWindow().setPosition(parseInt(x) - 50, parseInt(y) - 50);
+			picker.getWindow().webContents.send('updatePicker', color);
+			if (realtime) {
+				colorpicker.getWindow().webContents.send('previewColor', color);
+			}
+		});
 
-    ipcMain.on("closePicker", closePicker);
-  };
+		ioHook.on('mouseup', (event) => {
+			if (!picker.getWindow()) {
+				return;
+			}
+			if (event.button === 2) {
+				return closePicker();
+			}
+			let { x, y } = event;
+			closePicker(`#${robot.getPixelColor(parseInt(x), parseInt(y))}`);
+		});
 
-  ipcMain.on("pickerRequested", (event) => {
-    let realtime = storage.get("realtime", "picker");
-    if (process.platform !== "darwin" && process.platform !== "win32") {
-      return linuxSupport();
-    }
-    if (process.platform === "darwin") { mouseEvent = require("osx-mouse")(); }
-    if (process.platform === "win32") { mouseEvent = require("win-mouse")(); }
-    color = storage.get("lastColor");
+		let pos = robot.getMousePos();
+		picker.getWindow().setPosition(parseInt(pos.x) - 50, parseInt(pos.y) - 50);
 
-    picker.getWindow().on("close", () => mouseEvent.destroy());
+		picker
+			.getWindow()
+			.webContents.send('updatePicker', robot.getPixelColor(pos.x, pos.y));
 
-    mouseEvent.on("move", (x, y) => {
-      let color = `#${robot.getPixelColor(parseInt(x), parseInt(y))}`;
-      const positionScreen = screen.getCursorScreenPoint()
+		ipcMain.on('closePicker', closePicker);
+	};
 
-      picker.getWindow().setPosition(positionScreen.x - 50, positionScreen.y - 50);
-      picker.getWindow().webContents.send("updatePicker", color);
-      if (realtime) {
-        colorpicker.getWindow().webContents.send("previewColor", color);
-      }
-    });
+	ipcMain.on('pickerRequested', (event) => {
+		if (process.platform !== 'darwin' && process.platform !== 'win32') {
+			return linuxSupport();
+		}
 
-    mouseEvent.on("left-up", (x, y) => {
-      closePicker(`#${robot.getPixelColor(parseInt(x), parseInt(y))}`);
-    });
+		if (process.platform === 'darwin') {
+			mouseEvent = require('osx-mouse')();
+		}
 
-    const pos = screen.getCursorScreenPoint()
-    picker.getWindow().setPosition(pos.x - 50, pos.y - 50);
+		if (process.platform === 'win32') {
+			mouseEvent = require('win-mouse')();
+		}
+		color = storage.get('lastColor');
 
-    picker
-      .getWindow()
-      .webContents.send("updatePicker", robot.getPixelColor(pos.x, pos.y));
+		const pos = screen.getCursorScreenPoint();
+		picker.getWindow().setPosition(pos.x - 50, pos.y - 50);
 
-    ipcMain.on("closePicker", closePicker);
-    mouseEvent.on("right-up", closePicker);
-  });
+		picker
+			.getWindow()
+			.webContents.send('updatePicker', robot.getPixelColor(pos.x, pos.y));
+
+		picker.getWindow().on('closed', () => mouseEvent.destroy());
+		mouseEvent.on('move', mouseMoveEvent);
+		mouseEvent.on('left-up', leftClickEvent);
+		ipcMain.on('closePicker', closePicker);
+		mouseEvent.on('right-up', closePicker);
+	});
+
+	const mouseMoveEvent = (x, y) => {
+		const positionScreen = screen.getCursorScreenPoint();
+		picker
+			.getWindow()
+			.setPosition(positionScreen.x - 50, positionScreen.y - 50);
+
+		if (!lastUpdateTime || Date.now() - lastUpdateTime > pickerUpdateDelay) {
+			let realtime = storage.get('realtime', 'picker');
+			let color = `#${robot.getPixelColor(parseInt(x), parseInt(y))}`;
+			picker.getWindow().webContents.send('updatePicker', color);
+			if (realtime) {
+				colorpicker.getWindow().webContents.send('previewColor', color);
+			}
+			lastUpdateTime = Date.now();
+		}
+	};
+
+	const leftClickEvent = (x, y) => {
+		closePicker(`#${robot.getPixelColor(parseInt(x), parseInt(y))}`);
+	};
 };


### PR DESCRIPTION
Hello! First of all, thank you for the awesome colour picker tool; I use it all the time 😊

I've noticed that with the picker itself, sometimes it crashes after selecting a colour, and generally it is quite laggy when moving it around the screen to select said colour.

I believe I have resolved these issues by doing the following:
1. Adding a small delay of `100ms` before the picker window is destroyed
    a. This is because I think the `mouseEvent` handler was sometimes still processing at the same time as it gets destroyed along            with the window
    b. Adding the delay ensures that the `mouseEvent` has time to finish before the window is destroyed
2. Refactoring the event listeners so that they can be added/removed properly during `pickerRequested` and `closePicker` events
3. Debouncing the picker colour update requests to `25ms`
    a. Previously the colour update calls were being called as fast as possible, leading to lag
    b. Adding a small delay can help with that

I have tested this on my Windows 11 Desktop and it seems to have resolved the issues, but it would be great if someone else could verify that this resolves the issues!

Also, this should resolve #74 and hopefully also resolves #79 

If the code needs to be formatted in a specific way, please let me know and I can reformat it.

Thank you! 😊